### PR TITLE
문서 추가 요청 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// mariaDB 연결

--- a/src/main/java/com/zb/wiki/controller/DocumentController.java
+++ b/src/main/java/com/zb/wiki/controller/DocumentController.java
@@ -1,0 +1,45 @@
+package com.zb.wiki.controller;
+
+
+import com.zb.wiki.dto.CreateDocument;
+import com.zb.wiki.dto.CustomUserDetailsDto;
+import com.zb.wiki.dto.GlobalResponse;
+import com.zb.wiki.service.DocumentService;
+import com.zb.wiki.type.GlobalResponseStatus;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/document")
+@RequiredArgsConstructor
+@Slf4j
+public class DocumentController {
+  private final DocumentService documentService;
+
+
+  /**
+   * 문서 추가 요청 API
+   * @param request 문서의 제목, 내용, 태그
+   * @param member jwt를 통해 받은 유저 정보
+   * @return 문서 추가 요청 완료 메시지
+   */
+  @PostMapping
+  public ResponseEntity<GlobalResponse<String>> createDocumentPending(@Valid @RequestBody CreateDocument.Request request,
+      @AuthenticationPrincipal CustomUserDetailsDto member) {
+    log.info("Create document pending");
+    documentService.addDocumentPending(member.getId(), request.getTitle(), request.getContext(), request.getTags());
+    return ResponseEntity.ok().body(
+        GlobalResponse.<String>builder()
+            .status(GlobalResponseStatus.SUCCESS)
+            .message("문서 추가 요청 완료")
+            .build()
+    );
+  }
+}

--- a/src/main/java/com/zb/wiki/domain/Document.java
+++ b/src/main/java/com/zb/wiki/domain/Document.java
@@ -47,9 +47,9 @@ public class Document {
   private DocumentStatus documentStatus;
 
   @CreatedDate
-  private LocalDateTime createdDate;
+  private LocalDateTime createdDateTime;
   @LastModifiedDate
-  private LocalDateTime modifiedDate;
+  private LocalDateTime modifiedDateTime;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")

--- a/src/main/java/com/zb/wiki/domain/Document.java
+++ b/src/main/java/com/zb/wiki/domain/Document.java
@@ -1,0 +1,57 @@
+package com.zb.wiki.domain;
+
+import com.zb.wiki.type.DocumentStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Document {
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Id
+  private Long id;
+
+  @Column(unique = true)
+  @NotNull
+  private String title;
+  @NotNull
+  private String context;
+  @Column(nullable = true)
+  private String tag;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private DocumentStatus documentStatus;
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+  @LastModifiedDate
+  private LocalDateTime modifiedDate;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member modifiedBy;
+}

--- a/src/main/java/com/zb/wiki/domain/Member.java
+++ b/src/main/java/com/zb/wiki/domain/Member.java
@@ -51,9 +51,9 @@ public class Member{
   private String email;
 
   @CreatedDate
-  private LocalDateTime createdDate;
+  private LocalDateTime createdDateTime;
   @LastModifiedDate
-  private LocalDateTime modifiedDate;
+  private LocalDateTime modifiedDateTime;
 
   public void updateExistingUser(KakaoUserInfo kakaoUserInfo){
     this.username = kakaoUserInfo.getKakaoAccount().getProfile().getNickname();

--- a/src/main/java/com/zb/wiki/dto/CreateDocument.java
+++ b/src/main/java/com/zb/wiki/dto/CreateDocument.java
@@ -1,0 +1,19 @@
+package com.zb.wiki.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+
+public class CreateDocument {
+
+  @Getter
+  public static class Request{
+    @NotBlank
+    @Size(min = 1, max = 40)
+    private String title;
+    @NotBlank
+    private String context;
+    private List<String> tags;
+  }
+}

--- a/src/main/java/com/zb/wiki/dto/CreateDocument.java
+++ b/src/main/java/com/zb/wiki/dto/CreateDocument.java
@@ -3,11 +3,15 @@ package com.zb.wiki.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 public class CreateDocument {
 
   @Getter
+  @Builder
+  @AllArgsConstructor
   public static class Request{
     @NotBlank
     @Size(min = 1, max = 40)

--- a/src/main/java/com/zb/wiki/dto/CustomUserDetailsDto.java
+++ b/src/main/java/com/zb/wiki/dto/CustomUserDetailsDto.java
@@ -5,12 +5,16 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
+@Setter
 public class CustomUserDetailsDto implements UserDetails {
 
   private Long id;

--- a/src/main/java/com/zb/wiki/dto/CustomUserDetailsDto.java
+++ b/src/main/java/com/zb/wiki/dto/CustomUserDetailsDto.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @AllArgsConstructor
 public class CustomUserDetailsDto implements UserDetails {
 
+  private Long id;
   private String username;
   private String password;
   private String email;

--- a/src/main/java/com/zb/wiki/exception/GlobalError.java
+++ b/src/main/java/com/zb/wiki/exception/GlobalError.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum GlobalError {
+  DOCUMENT_TITLE_DUPLICATED("문서의 제목이 이미 중복되어 있습니다", HttpStatus.BAD_REQUEST),
   RESOURCE_SERVER_ERROR("리소스 서버의 에러입니다", HttpStatus.INTERNAL_SERVER_ERROR),
   USERNAME_DUPLICATED("중복 아이디입니다", HttpStatus.CONFLICT),
   BAD_REQUEST("유효하지않은 요청입니다", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/zb/wiki/repository/DocumentRepository.java
+++ b/src/main/java/com/zb/wiki/repository/DocumentRepository.java
@@ -1,0 +1,10 @@
+package com.zb.wiki.repository;
+
+import com.zb.wiki.domain.Document;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+  boolean existsByTitle(String title);
+}

--- a/src/main/java/com/zb/wiki/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zb/wiki/security/JwtAuthenticationFilter.java
@@ -25,7 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     String username = null;
     String jwt = null;
 
-    if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+    if (authorizationHeader != null && authorizationHeader.startsWith("BEARER ")) {
       jwt = authorizationHeader.substring(7);
       username = jwtProvider.getUsernameFromToken(jwt);
     }

--- a/src/main/java/com/zb/wiki/service/CustomUserDetailService.java
+++ b/src/main/java/com/zb/wiki/service/CustomUserDetailService.java
@@ -22,6 +22,7 @@ public class CustomUserDetailService implements UserDetailsService {
     Member member = memberRepository.findByUsername(username)
         .orElseThrow(() -> new GlobalException(GlobalError.USER_NOT_FOUND));
     return CustomUserDetailsDto.builder()
+        .id(member.getId())
         .username(member.getUsername())
         .password(member.getPassword())
         .email(member.getEmail())

--- a/src/main/java/com/zb/wiki/service/DocumentService.java
+++ b/src/main/java/com/zb/wiki/service/DocumentService.java
@@ -46,10 +46,8 @@ public class DocumentService {
       throw new GlobalException(GlobalError.DOCUMENT_TITLE_DUPLICATED);
     }
 
-    String tag = null;
-    if (tags != null && !tags.isEmpty()) {
-      tag = setTag(tags);
-    }
+    String tag = setTag(tags);
+
     documentRepository.save(
         Document.builder()
             .documentStatus(DocumentStatus.PENDING)
@@ -69,6 +67,10 @@ public class DocumentService {
    * @return String
    */
   private String setTag(List<String> tags) {
-    return String.join(TAG_DELIMITER, tags);
+    if(tags != null && !tags.isEmpty()){
+      return String.join(TAG_DELIMITER, tags);
+    }else{
+      return null;
+    }
   }
 }

--- a/src/main/java/com/zb/wiki/service/DocumentService.java
+++ b/src/main/java/com/zb/wiki/service/DocumentService.java
@@ -1,0 +1,74 @@
+package com.zb.wiki.service;
+
+
+import com.zb.wiki.domain.Document;
+import com.zb.wiki.domain.Member;
+import com.zb.wiki.exception.GlobalError;
+import com.zb.wiki.exception.GlobalException;
+import com.zb.wiki.repository.DocumentRepository;
+import com.zb.wiki.repository.MemberRepository;
+import com.zb.wiki.type.DocumentStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class DocumentService {
+
+  private static final String TAG_DELIMITER = "|";
+  private final DocumentRepository documentRepository;
+  private final MemberRepository memberRepository;
+
+
+  /**
+   * 문서 추가 요청 로직
+   * 1. jwt로 통해 받은 userid로 사용자 인증
+   * 2. 문서 제목이 중복인지 확인
+   * 3. List로 입력받은 태그 String으로 변환 후
+   * 4. 문서 상태를 Pending으로 저장
+   * @param id jwt UserID
+   * @param title 문서 제목
+   * @param context 문서 내용
+   * @param tags 문서 태그
+   */
+  @Transactional(readOnly = false)
+  public void addDocumentPending(Long id, String title, String context, List<String> tags) {
+    Member member = memberRepository.findById(id).orElseThrow(
+        () -> new GlobalException(GlobalError.USER_NOT_FOUND)
+    );
+
+    if (documentRepository.existsByTitle(title)) {
+      throw new GlobalException(GlobalError.DOCUMENT_TITLE_DUPLICATED);
+    }
+
+    String tag = null;
+    if (tags != null && !tags.isEmpty()) {
+      tag = setTag(tags);
+    }
+    documentRepository.save(
+        Document.builder()
+            .documentStatus(DocumentStatus.PENDING)
+            .title(title)
+            .context(context)
+            .tag(tag)
+            .modifiedBy(member)
+            .build()
+    );
+  }
+
+
+  /**
+   * 태그 List -> String
+   * 태그 사이는 | 로 구분
+   * @param tags 태그 List
+   * @return String
+   */
+  private String setTag(List<String> tags) {
+    return String.join(TAG_DELIMITER, tags);
+  }
+}

--- a/src/main/java/com/zb/wiki/type/DocumentStatus.java
+++ b/src/main/java/com/zb/wiki/type/DocumentStatus.java
@@ -1,0 +1,7 @@
+package com.zb.wiki.type;
+
+public enum DocumentStatus {
+  PENDING,       // 등록
+  APPROVED,      // 승인
+  REJECTED       // 거절
+}

--- a/src/test/java/com/zb/wiki/controller/AuthControllerTest.java
+++ b/src/test/java/com/zb/wiki/controller/AuthControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.zb.wiki.security.JwtProvider;
 import com.zb.wiki.service.MemberService;
+import com.zb.wiki.service.Oauth2Service;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -27,6 +28,8 @@ class AuthControllerTest {
   private MemberService memberService;
   @MockBean
   private JwtProvider jwtProvider;
+  @MockBean
+  private Oauth2Service oauth2Service;
   @Autowired
   private MockMvc mockMvc;
 

--- a/src/test/java/com/zb/wiki/controller/DocumentControllerTest.java
+++ b/src/test/java/com/zb/wiki/controller/DocumentControllerTest.java
@@ -1,0 +1,62 @@
+package com.zb.wiki.controller;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zb.wiki.custom.WithCustomMockUser;
+import com.zb.wiki.dto.CreateDocument;
+import com.zb.wiki.security.JwtProvider;
+import com.zb.wiki.service.DocumentService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = DocumentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DocumentControllerTest {
+
+  @MockBean
+  private DocumentService documentService;
+  @MockBean
+  private JwtProvider jwtProvider;
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+
+  @Test
+  @DisplayName("문서 추가 요청 성공")
+  @WithCustomMockUser
+  void createDocumentPending_success() throws Exception {
+    //given
+    Mockito.doNothing().when(documentService)
+        .addDocumentPending(anyLong(), anyString(), anyString(),
+            anyList());
+    CreateDocument.Request request = CreateDocument.Request.builder()
+        .title("title")
+        .context("context")
+        .tags(new ArrayList<>(Arrays.asList("tag1", "tag2")))
+        .build();
+    //when
+    //then
+    mockMvc.perform(post("/document")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+        ).andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("문서 추가 요청 완료"));
+  }
+}

--- a/src/test/java/com/zb/wiki/custom/WithCustomMockUser.java
+++ b/src/test/java/com/zb/wiki/custom/WithCustomMockUser.java
@@ -1,0 +1,18 @@
+package com.zb.wiki.custom;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+
+  long id() default 1L;
+
+  String username() default "username";
+
+  String password() default "password";
+
+  String email() default "email@email.com";
+}

--- a/src/test/java/com/zb/wiki/custom/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/zb/wiki/custom/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,32 @@
+package com.zb.wiki.custom;
+
+import com.zb.wiki.dto.CustomUserDetailsDto;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+    Long id = annotation.id();
+    String username = annotation.username();
+    String password = annotation.password();
+    String email = annotation.email();
+
+    //여기서 바인딩되어 반환할 객체를 정의해주면 됩니다
+    CustomUserDetailsDto user = CustomUserDetailsDto.builder()
+        .id(id)
+        .username(username)
+        .password(password)
+        .email(email)
+        .build();
+
+    UsernamePasswordAuthenticationToken token =
+        new UsernamePasswordAuthenticationToken(user, "password");
+    SecurityContext context = SecurityContextHolder.getContext();
+    context.setAuthentication(token);
+    return context;
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**

1. 문서 추가 API를 추가하였습니다.

* 문서 추가 API는 인증이 된 유저(Jwt를 통해)만 사용 가능합니다.
* 문서 추가 API의 요청 데이터에는 문서의 제목, 내용, 태그가 있습니다.
* 태그는 List를 통해받지만 DB에는 특수문자 | 를 사용하여 하나의 칼럼에 저장됩니다.
* 문서의 제목이 일치하는 문서가 없어야합니다
* 문서 추가 API가 성공적으로 수행되면 문서는 승인 대기문서(pending)이 됩니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
* 문서 추가 요청 API Controller 테스트
- [x] API 테스트 
* 문서 추가 요청 API 테스트 
